### PR TITLE
Add friendly match RPC support

### DIFF
--- a/Scripts/Menu/Common/Profile/FriendEntry.cs
+++ b/Scripts/Menu/Common/Profile/FriendEntry.cs
@@ -2,6 +2,7 @@
 using Nakama;
 using System.Threading.Tasks;
 using UnityEngine;
+using Dawnshard.Menu;
 
 public class FriendEntry : UserEntry
 {
@@ -82,14 +83,13 @@ public class FriendEntry : UserEntry
     /// <summary>
     /// Send an invitation to the player to fight
     /// </summary>
-    public async void SendMatchInvitationAsync()
+    [SerializeField] private FriendlyMatchPopup friendlyPopup;
+
+    public void SendMatchInvitationAsync()
     {
-        //add asset referencer and uncomment
-        //NakamaConnection conn = AssetReferencer.Instance.connection;
-
-        //var match = await conn.FindMatch(false);
-        //conn.SendFriendlyMatchInvitation(user.Id, match.matchId);
-
-        //FriendlyMatchState.StartFriendlyMatch(user.Username, match.matchId);
+        if(friendlyPopup != null)
+        {
+            friendlyPopup.OpenAsSender(user.Id);
+        }
     }
 }

--- a/Scripts/Menu/Popups/FriendlyMatchPopup.cs
+++ b/Scripts/Menu/Popups/FriendlyMatchPopup.cs
@@ -1,0 +1,81 @@
+using Dawnshard.Menu;
+using Dawnshard.Presenters;
+using Dawnshard.Database;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class FriendlyMatchPopup : Popup
+{
+    [SerializeField] private Button playButton;
+    [SerializeField] private Transform deckParent;
+
+    private readonly List<InteractableDeckPresenter> deckPresenters = new();
+    private DeckModel selectedDeck;
+    private string friendId;
+    private string matchId;
+    private bool isSender;
+
+    protected override void Start()
+    {
+        base.Start();
+        playButton.onClick.AddListener(OnPlayClicked);
+    }
+
+    public void OpenAsSender(string friendId)
+    {
+        this.friendId = friendId;
+        isSender = true;
+        BuildDeckList();
+        playButton.interactable = false;
+        base.Open();
+    }
+
+    public void OpenAsReceiver(string matchId)
+    {
+        this.matchId = matchId;
+        isSender = false;
+        BuildDeckList();
+        playButton.interactable = false;
+        base.Open();
+    }
+
+    private void BuildDeckList()
+    {
+        foreach (var presenter in deckPresenters)
+        {
+            Object.Destroy(presenter);
+        }
+        deckPresenters.Clear();
+
+        foreach (var deck in GameController.Instance.Decks)
+        {
+            var presenter = DeckFactory.Instance.CreateInteractableDeckView(deck, deckParent);
+            presenter.ToggleButtonListener(true, () => OnDeckSelected(presenter));
+            deckPresenters.Add(presenter);
+        }
+    }
+
+    private void OnDeckSelected(InteractableDeckPresenter presenter)
+    {
+        selectedDeck = presenter.Model;
+        playButton.interactable = true;
+    }
+
+    private void OnPlayClicked()
+    {
+        if (selectedDeck == null)
+            return;
+
+        if (isSender)
+        {
+            GameController.Instance.SendFriendlyMatchRequest(selectedDeck.Name, friendId);
+        }
+        else
+        {
+            GameController.Instance.AcceptFriendlyMatch(matchId, selectedDeck.Name);
+        }
+
+        Close();
+    }
+}

--- a/Scripts/Menu/Popups/FriendlyMatchPopup.cs.meta
+++ b/Scripts/Menu/Popups/FriendlyMatchPopup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2cc63d503ee4b62b36a4f4944000abc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Scripts/Menu/Utils/FriendlyMatchNotifier.cs
+++ b/Scripts/Menu/Utils/FriendlyMatchNotifier.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using Dawnshard.Menu;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class FriendlyMatchNotifier : MonoBehaviour
+{
+    [SerializeField] private FriendlyMatchPopup friendlyPopup;
+    [SerializeField] private Button challengeButtonPrefab;
+    [SerializeField] private Transform challengeButtonParent;
+
+    private const float CHECK_INTERVAL = 5f;
+    private float timer = 0f;
+
+    private readonly List<Button> spawnedButtons = new();
+
+    private async void Update()
+    {
+        if (GameController.Instance == null || GameController.Instance.Session == null)
+            return;
+
+        timer -= Time.deltaTime;
+        if (timer > 0f)
+            return;
+        timer = CHECK_INTERVAL;
+
+        var notifications = await GameController.Instance.ReadNotification();
+        foreach (var notification in notifications)
+        {
+            if (notification.Code != 1)
+                continue;
+            if (notification.Content != null && notification.Content.ContainsKey("matchId"))
+            {
+                string matchId = notification.Content["matchId"].ToString();
+                string username = notification.Content.ContainsKey("username") ? notification.Content["username"].ToString() : "";
+
+                SpawnChallengeButton(matchId, username);
+                await GameController.Instance.DeleteNotification(new List<string> { notification.Id });
+            }
+        }
+    }
+
+    private void SpawnChallengeButton(string matchId, string username)
+    {
+        var button = Instantiate(challengeButtonPrefab, challengeButtonParent);
+        var text = button.GetComponentInChildren<TMPro.TMP_Text>();
+        if (text != null)
+            text.text = username + " has challenged you!";
+
+        button.onClick.AddListener(() => OnChallengeButtonClicked(matchId, button));
+        spawnedButtons.Add(button);
+    }
+
+    private void OnChallengeButtonClicked(string matchId, Button button)
+    {
+        friendlyPopup.OpenAsReceiver(matchId);
+        spawnedButtons.Remove(button);
+        Destroy(button.gameObject);
+    }
+}

--- a/Scripts/Menu/Utils/FriendlyMatchNotifier.cs.meta
+++ b/Scripts/Menu/Utils/FriendlyMatchNotifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6848b74fa700490396c14d90276a9674
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add deck selection popup to handle friendly match challenges
- notify play state with challenge button and open deck selection
- allow friend entry to send challenges via the new popup

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_684aea14da7483308b520f298393aa69