### PR TITLE
Implement dynamic animation timing

### DIFF
--- a/Scripts/Client/Network/EventDispatcher.cs
+++ b/Scripts/Client/Network/EventDispatcher.cs
@@ -226,11 +226,14 @@ namespace Dawnshard.Network
 
                         if (gameEvent.CardMovedTriggered.DestZoneId == Constants.GraveyardZone && gameEvent.CardMovedTriggered.OrigZoneId != Constants.ActionZone)
                             break;
-                        if (gameEvent.CardMovedTriggered.DestZoneId == Constants.BoardZone)
-                            yield return new WaitForSeconds(2f);
-                        else
+                        if (gameEvent.CardMovedTriggered.DestZoneId != Constants.GraveyardZone ||
+                            gameEvent.CardMovedTriggered.OrigZoneId == Constants.ActionZone)
                         {
-                            yield return new WaitForSeconds(1.2f);
+                            var cardPresenter = ZonePresenter.GetCardPresenter(gameEvent.CardMovedTriggered.CardId);
+                            var duration = cardPresenter?.GetMoveDuration(gameEvent.CardMovedTriggered.OrigZoneId,
+                                gameEvent.CardMovedTriggered.DestZoneId) ?? 0f;
+                            if (duration > 0f)
+                                yield return new WaitForSeconds(duration);
                         }
 
                         break;
@@ -264,7 +267,11 @@ namespace Dawnshard.Network
                     {
                         eventBusManager.CardEventBus.Publish(gameEvent.CardReadyChanged.CardId,
                             new CardReadyChangedEvent(gameEvent.CardReadyChanged.CanFight, gameEvent.CardReadyChanged.CanReap));
-                        yield return new WaitForSeconds(1f);
+
+                        var readyPresenter = ZonePresenter.GetCardPresenter(gameEvent.CardReadyChanged.CardId);
+                        var readyDuration = readyPresenter?.ReadyChangeDuration ?? 0f;
+                        if (readyDuration > 0f)
+                            yield return new WaitForSeconds(readyDuration);
 
                         break;
                     }
@@ -290,7 +297,10 @@ namespace Dawnshard.Network
                         eventBusManager.CardEventBus?.Publish(gameEvent.PlayerAbilityTriggered.SourceCardId,
                             new PlayerAbilityTriggeredEvent(gameEvent.PlayerAbilityTriggered.Ability.TriggerID, gameEvent.PlayerAbilityTriggered.Ability.EffectID, gameEvent.PlayerAbilityTriggered.SourceCardId, gameEvent.PlayerAbilityTriggered.TargetPlayerIds.ToList()));
 
-                        yield return new WaitForSeconds(1f);
+                        var abilityPresenter = ZonePresenter.GetCardPresenter(gameEvent.PlayerAbilityTriggered.SourceCardId);
+                        var abilityDuration = abilityPresenter?.AbilityDuration ?? 0f;
+                        if (abilityDuration > 0f)
+                            yield return new WaitForSeconds(abilityDuration);
 
                         break;
                     }
@@ -307,7 +317,10 @@ namespace Dawnshard.Network
                         eventBusManager.CardEventBus.Publish(gameEvent.ReapCreatureEvent.CardId,
                             new ReapCreatureTriggered(gameEvent.ReapCreatureEvent.CardId));
 
-                        yield return new WaitForSeconds(1f);
+                        var reapPresenter = ZonePresenter.GetCardPresenter(gameEvent.ReapCreatureEvent.CardId);
+                        var reapDuration = reapPresenter?.ReapDuration ?? 0f;
+                        if (reapDuration > 0f)
+                            yield return new WaitForSeconds(reapDuration);
 
                         break;
                     }
@@ -317,10 +330,10 @@ namespace Dawnshard.Network
                         eventBusManager.CardEventBus.Publish(gameEvent.FightCreatureEvent.DefenderId,
                             new FightCreatureTriggered(gameEvent.FightCreatureEvent.AttackerId, gameEvent.FightCreatureEvent.DefenderId));
 
-                        //eventBusManager.CardEventBus.Publish(gameEvent.FightCreatureEvent.DefenderId,
-                        //    new FightCreatureTriggered(gameEvent.FightCreatureEvent.AttackerId, gameEvent.FightCreatureEvent.DefenderId));
-
-                        yield return new WaitForSeconds(1f);
+                        var fightPresenter = ZonePresenter.GetCardPresenter(gameEvent.FightCreatureEvent.AttackerId);
+                        var fightDuration = fightPresenter?.FightDuration ?? 0f;
+                        if (fightDuration > 0f)
+                            yield return new WaitForSeconds(fightDuration);
 
                         break;
                     }

--- a/Scripts/Client/Network/Interfaces/ICardPresenter.cs
+++ b/Scripts/Client/Network/Interfaces/ICardPresenter.cs
@@ -44,5 +44,30 @@ namespace Dawnshard.Network
         /// Resize the frame of the card to big or small
         /// </summary>
         void ChangeCardFrame(bool growFrame);
+
+        /// <summary>
+        /// Duration of the move animation between two zones
+        /// </summary>
+        float GetMoveDuration(string origZone, string destZoneId);
+
+        /// <summary>
+        /// Duration of the reap animation
+        /// </summary>
+        float ReapDuration { get; }
+
+        /// <summary>
+        /// Duration of the fight animation
+        /// </summary>
+        float FightDuration { get; }
+
+        /// <summary>
+        /// Duration of the ready change animation
+        /// </summary>
+        float ReadyChangeDuration { get; }
+
+        /// <summary>
+        /// Duration of the ability trigger animation
+        /// </summary>
+        float AbilityDuration { get; }
     }
 }

--- a/Scripts/Client/Presenters/CardPresenter.cs
+++ b/Scripts/Client/Presenters/CardPresenter.cs
@@ -476,6 +476,19 @@ namespace Dawnshard.Presenters
         {
             CardView.SetSortingGroupOrderInLayer(i);
         }
+
+        public float GetMoveDuration(string origZone, string destZoneId)
+        {
+            return CardView.GetMoveDuration(origZone, destZoneId);
+        }
+
+        public float ReapDuration => CardView.ReapDuration;
+
+        public float FightDuration => CardView.FightDuration;
+
+        public float ReadyChangeDuration => CardView.ReadyChangeDuration;
+
+        public float AbilityDuration => CardView.AbilityDuration;
         #endregion
     }
 }

--- a/Scripts/Client/Presenters/ZonePresenter.cs
+++ b/Scripts/Client/Presenters/ZonePresenter.cs
@@ -144,6 +144,11 @@ namespace Dawnshard.Presenters
             cardPresenters.Clear();
         }
 
+        public static ICardPresenter GetCardPresenter(int cardId)
+        {
+            return cardPresenters.GetValueOrDefault(cardId, null);
+        }
+
         public void RemoveCard(int cardId)
         {
             Model.NumCards--;

--- a/Scripts/Client/Views/Cards/CardView.cs
+++ b/Scripts/Client/Views/Cards/CardView.cs
@@ -471,6 +471,34 @@ namespace Dawnshard.Views
             OnUserInput?.Invoke(UserInput.MouseUp);
         }
 
+        public float GetMoveDuration(string origZone, string destZone)
+        {
+            float duration = 0f;
+            var origZoneAnimations = animationByMovementIds.GetAllItems(origZone);
+            foreach (var dict in origZoneAnimations)
+            {
+                var moveFeedbacks = dict.GetAllItems(destZone);
+                foreach (var feedbacks in moveFeedbacks)
+                {
+                    if (feedbacks != null)
+                    {
+                        duration = Mathf.Max(duration, feedbacks.TotalDuration);
+                    }
+                }
+            }
+
+            return duration;
+        }
+
+        public float ReapDuration => reapAnimation != null ? reapAnimation.TotalDuration : 0f;
+
+        public float FightDuration => fightAnimation != null ? fightAnimation.TotalDuration : 0f;
+
+        public float ReadyChangeDuration => Mathf.Max(growFrameAnimation != null ? growFrameAnimation.TotalDuration : 0f,
+            shrinkFrameAnimation != null ? shrinkFrameAnimation.TotalDuration : 0f);
+
+        public float AbilityDuration => triggerActivatedAnimation != null ? triggerActivatedAnimation.TotalDuration : 0f;
+
 
         [Serializable]
         public class SettingByZone


### PR DESCRIPTION
## Summary
- expose animation durations through the card view and presenter
- allow zone presenters to retrieve card presenters
- use animation durations in EventDispatcher instead of fixed waits
- extend `ICardPresenter` with duration helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aee85aa34833095724215cece3bd5