### PR TITLE
Implement friendly match

### DIFF
--- a/Scripts/Menu/Popups/FriendlyMatchPopup.cs
+++ b/Scripts/Menu/Popups/FriendlyMatchPopup.cs
@@ -1,0 +1,43 @@
+using System;
+using Dawnshard.Menu;
+
+public class FriendlyMatchPopup : RankedMatchPopup
+{
+    private bool isSender;
+    private string friendId;
+    private string matchId;
+
+    public void SetChallenge(GameController.FriendChallenge challenge)
+    {
+        isSender = false;
+        matchId = challenge.MatchId;
+    }
+
+    public void SetChallengeAsSender(string friendId)
+    {
+        isSender = true;
+        this.friendId = friendId;
+    }
+
+    protected override async void StartAIMatchAsync()
+    {
+        PlayWaitingAnimation();
+        try
+        {
+            if (isSender)
+            {
+                await GameController.Instance.StartFriendlyMatch(friendId, deckPresenter.Model.Name);
+            }
+            else
+            {
+                await GameController.Instance.AcceptFriendlyMatch(matchId, deckPresenter.Model.Name);
+            }
+            isSearchingForMatch = true;
+        }
+        catch (Exception e)
+        {
+            UnityEngine.Debug.LogException(e);
+            ShowError(e.Message);
+        }
+    }
+}

--- a/Scripts/Menu/States/HomeState.cs
+++ b/Scripts/Menu/States/HomeState.cs
@@ -89,7 +89,15 @@ namespace Dawnshard.Menu
             int spawnedQuests = 0;
             foreach (var notification in notifications)
             {
-                if (notification.Code == 2 || notification.Code == 3)
+                if (notification.Code == 1)
+                {
+                    var challengeData = JsonConvert.DeserializeObject<Dictionary<string, string>>(notification.Content);
+                    if (challengeData != null && challengeData.ContainsKey("matchId") && challengeData.ContainsKey("username"))
+                    {
+                        GameController.Instance.AddFriendChallenge(challengeData["matchId"], challengeData["username"]);
+                    }
+                }
+                else if (notification.Code == 2 || notification.Code == 3)
                 {
                     if (spawnedQuests >= 3)
                     {


### PR DESCRIPTION
## Summary
- add RPC constant and request for friendly matches
- store pending friendly challenges in GameController
- implement methods to start or accept friendly matches
- parse challenge notifications in HomeState and spawn deck selection via PlayState
- support friendly match deck selection in PlayState using a new `FriendlyMatchPopup`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684af2bebd2c8330a4b8a403901c8d02