### PR TITLE
Add SystemNotificationUI component

### DIFF
--- a/Scripts/Menu/SystemNotificationUI.cs
+++ b/Scripts/Menu/SystemNotificationUI.cs
@@ -1,0 +1,118 @@
+using System;
+using Nakama;
+using MoreMountains.Feedbacks;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SystemNotificationUI : MonoBehaviour
+{
+    [SerializeField] private TMP_Text notificationText;
+    [SerializeField] private Button acceptButton;
+    [SerializeField] private Button rejectButton;
+    [SerializeField] private MMFeedbacks newNotificationFeedback;
+
+    private IApiNotification currentNotification;
+
+    private void OnEnable()
+    {
+        if (GameController.Instance != null && GameController.Instance.Socket != null)
+        {
+            GameController.Instance.Socket.ReceivedNotification += OnNotificationReceived;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (GameController.Instance != null && GameController.Instance.Socket != null)
+        {
+            GameController.Instance.Socket.ReceivedNotification -= OnNotificationReceived;
+        }
+    }
+
+    private void OnNotificationReceived(IApiNotification notification)
+    {
+        currentNotification = notification;
+
+        if (notificationText != null)
+        {
+            notificationText.text = notification.Subject;
+        }
+
+        bool requiresResponse = notification.Code == 1;
+
+        if (acceptButton != null)
+        {
+            acceptButton.gameObject.SetActive(requiresResponse);
+            acceptButton.onClick.RemoveAllListeners();
+            if (requiresResponse)
+            {
+                acceptButton.onClick.AddListener(AcceptRequest);
+            }
+        }
+
+        if (rejectButton != null)
+        {
+            rejectButton.gameObject.SetActive(requiresResponse);
+            rejectButton.onClick.RemoveAllListeners();
+            if (requiresResponse)
+            {
+                rejectButton.onClick.AddListener(RejectRequest);
+            }
+        }
+
+        newNotificationFeedback?.PlayFeedbacks();
+    }
+
+    private async void AcceptRequest()
+    {
+        if (currentNotification == null)
+            return;
+
+        try
+        {
+            await FriendsAPI.AcceptFriend(currentNotification.SenderUsername);
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+        }
+
+        ClearNotification();
+    }
+
+    private async void RejectRequest()
+    {
+        if (currentNotification == null)
+            return;
+
+        try
+        {
+            await FriendsAPI.RemoveFriend(currentNotification.SenderUsername);
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+        }
+
+        ClearNotification();
+    }
+
+    private void ClearNotification()
+    {
+        if (notificationText != null)
+        {
+            notificationText.text = string.Empty;
+        }
+        if (acceptButton != null)
+        {
+            acceptButton.gameObject.SetActive(false);
+        }
+        if (rejectButton != null)
+        {
+            rejectButton.gameObject.SetActive(false);
+        }
+
+        currentNotification = null;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SystemNotificationUI` to handle real-time notifications via Nakama socket
- play an MMFeedback when a notification arrives and update the UI
- enable Accept/Reject buttons for friend requests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e9b2476348330a74e2bcaf96d330a