### PR TITLE
Add localization manager and localized text components

### DIFF
--- a/Scripts/Client/Localization/LocalizationManager.cs
+++ b/Scripts/Client/Localization/LocalizationManager.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using UnityEngine;
+
+public class LocalizationManager : MonoBehaviour
+{
+    private const string RESOURCE_PATH = "Localization";
+
+    private static LocalizationManager instance;
+    public static LocalizationManager Instance => instance;
+
+    public static event Action OnLanguageChanged;
+
+    private readonly Dictionary<string, Dictionary<string, string>> languages = new();
+    private Dictionary<string, string> currentLanguage;
+
+    public string CurrentLanguageId { get; private set; }
+
+    private void Awake()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+            LoadLanguages();
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (instance == this)
+        {
+            instance = null;
+        }
+    }
+
+    private void LoadLanguages()
+    {
+        TextAsset[] files = Resources.LoadAll<TextAsset>(RESOURCE_PATH);
+        foreach (var file in files)
+        {
+            try
+            {
+                var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(file.text);
+                languages[file.name] = dict ?? new Dictionary<string, string>();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to parse language file {file.name}: {e}");
+            }
+        }
+
+        if (files.Length > 0 && currentLanguage == null)
+        {
+            // try to use the system language first
+            string systemLang = Application.systemLanguage.ToString();
+            foreach (var id in languages.Keys)
+            {
+                if (string.Equals(id, systemLang, StringComparison.OrdinalIgnoreCase))
+                {
+                    SetLanguage(id);
+                    return;
+                }
+            }
+
+            // fallback to the first language we loaded
+            SetLanguage(files[0].name);
+        }
+    }
+
+    public void SetLanguage(string id)
+    {
+        if (string.IsNullOrEmpty(id) || !languages.ContainsKey(id))
+        {
+            Debug.LogWarning($"Language '{id}' not found");
+            return;
+        }
+
+        CurrentLanguageId = id;
+        currentLanguage = languages[id];
+        OnLanguageChanged?.Invoke();
+    }
+
+    public string Get(string key)
+    {
+        if (currentLanguage == null)
+        {
+            return key;
+        }
+
+        if (currentLanguage.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        return key;
+    }
+}
+

--- a/Scripts/Client/Localization/LocalizationManager.cs.meta
+++ b/Scripts/Client/Localization/LocalizationManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7164910b-eacc-4a08-af60-c1d641fac576
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Scripts/Client/Localization/LocalizedText.cs
+++ b/Scripts/Client/Localization/LocalizedText.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class LocalizedText : MonoBehaviour
+{
+    [SerializeField] private string key;
+
+    private TMP_Text tmpText;
+    private Text uiText;
+
+    private void Awake()
+    {
+        tmpText = GetComponent<TMP_Text>();
+        uiText = GetComponent<Text>();
+    }
+
+    private void OnEnable()
+    {
+        LocalizationManager.OnLanguageChanged += UpdateText;
+        UpdateText();
+    }
+
+    private void OnDisable()
+    {
+        LocalizationManager.OnLanguageChanged -= UpdateText;
+    }
+
+    private void UpdateText()
+    {
+        if (LocalizationManager.Instance == null)
+        {
+            return;
+        }
+
+        string value = LocalizationManager.Instance.Get(key);
+        if (tmpText != null)
+        {
+            tmpText.text = value;
+        }
+        else if (uiText != null)
+        {
+            uiText.text = value;
+        }
+    }
+
+    public void SetKey(string newKey)
+    {
+        key = newKey;
+        UpdateText();
+    }
+}
+

--- a/Scripts/Client/Localization/LocalizedText.cs.meta
+++ b/Scripts/Client/Localization/LocalizedText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 246c25ef-30a9-46b5-b570-dbca7c25aa1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `LocalizationManager` singleton for loading language files from `Resources/Localization`
- allow changing current language and retrieving localized strings
- create `LocalizedText` component that updates UI text when language changes
- default to the system language when available

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68679e76d5308330914c19485a05bfcf