### PR TITLE
Refactor match popups

### DIFF
--- a/Scripts/Menu/Popups/MatchPopup.cs
+++ b/Scripts/Menu/Popups/MatchPopup.cs
@@ -1,0 +1,145 @@
+using Dawnshard.Menu;
+using Dawnshard.Network;
+using System;
+using System.Collections;
+using MoreMountains.Feedbacks;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Dawnshard.Views;
+using Dawnshard.Presenters;
+
+namespace Dawnshard.Menu
+{
+    public abstract class MatchPopup : Popup
+    {
+        [SerializeField] protected Button findMatchButton;
+        [SerializeField] protected MMFeedbacks openAnimation;
+        [SerializeField] protected MMFeedbacks waitingAnimation;
+        [SerializeField] protected Transform closePosition;
+        [SerializeField] protected GameObject deckParent;
+        [SerializeField] protected TMP_Text timerText;
+        [SerializeField] protected TMP_Text titleText;
+
+        protected DeckPresenter deckPresenter;
+        private bool isOpen = false;
+        public bool isSearchingForMatch = false;
+        private float timer;
+
+        protected Action OnPopupClosed;
+
+        protected override void Start()
+        {
+            timer = 0f;
+            base.Start();
+            if (findMatchButton != null)
+                findMatchButton.onClick.AddListener(ManageSearch);
+        }
+
+        private void ManageSearch()
+        {
+            if (!isSearchingForMatch)
+            {
+                StartMatchAsync();
+            }
+            else
+            {
+                CancelMatchAsync();
+            }
+        }
+
+        private void Update()
+        {
+            if (isSearchingForMatch)
+            {
+                timer += Time.deltaTime;
+                float minutes = Mathf.FloorToInt(timer / 60);
+                float seconds = Mathf.FloorToInt(timer % 60);
+                if (timerText != null)
+                    timerText.text = string.Format("{0:00}:{1:00}", minutes, seconds);
+            }
+            else
+            {
+                timer = 0f;
+            }
+        }
+
+        public virtual void SetDeckView(DeckModel deck, Action OnEnd)
+        {
+            if (deckPresenter == null)
+            {
+                deckPresenter = DeckFactory.Instance.CreateDeckView(deck, deckParent.transform);
+            }
+            else
+            {
+                deckPresenter.Model = deck;
+                deckPresenter.UpdateView();
+            }
+            OnPopupClosed = OnEnd;
+        }
+
+        protected abstract void StartMatchAsync();
+
+        protected virtual async void CancelMatchAsync() { }
+
+        public override void Open()
+        {
+            if (isOpen)
+                return;
+            base.Open();
+            openAnimation.PlayFeedbacks();
+            isOpen = true;
+            timer = 0f;
+        }
+
+        public void SetOnCloseAction(Action OnClose)
+        {
+            OnPopupClosed += OnClose;
+        }
+
+        public override void Close()
+        {
+            if (!isOpen)
+                return;
+            StartCoroutine(CloseCoroutine());
+        }
+
+        public void CloseInstantly()
+        {
+            if (!isOpen)
+                return;
+            GetComponent<RectTransform>().position = closePosition.GetComponent<RectTransform>().position;
+            isOpen = false;
+            base.Close();
+            OnPopupClosed?.Invoke();
+        }
+
+        private IEnumerator CloseCoroutine()
+        {
+            openAnimation.PlayFeedbacks();
+            yield return new WaitWhile(() => openAnimation.IsPlaying || isSearchingForMatch);
+            isOpen = false;
+            OnPopupClosed?.Invoke();
+            base.Close();
+        }
+
+        protected void UndoWaitingAnimation()
+        {
+            if (!isSearchingForMatch)
+                return;
+            waitingAnimation.PlayFeedbacks();
+        }
+
+        protected void StopWaitingAnimation()
+        {
+            waitingAnimation.StopFeedbacks();
+        }
+
+        protected void PlayWaitingAnimation()
+        {
+            if (isSearchingForMatch)
+                return;
+            waitingAnimation.PlayFeedbacks();
+        }
+    }
+}

--- a/Scripts/Menu/Popups/QuestMatchPopup.cs
+++ b/Scripts/Menu/Popups/QuestMatchPopup.cs
@@ -2,14 +2,13 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Dawnshard.Menu;
-using Dawnshard.Network;
 using Dawnshard.Presenters;
 using TMPro;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class QuestMatchPopup : RankedMatchPopup
+public class QuestMatchPopup : TrainingMatchPopup
 {
     [SerializeField] private Button firstQuestButton;
     [SerializeField] private Button secondQuestButton;
@@ -67,9 +66,7 @@ public class QuestMatchPopup : RankedMatchPopup
     {
         tutorialNumber = GameController.Instance.UserMetadata.CompletedTutorials;
         //tutorialNumber = GameController.Instance.GetTutorialStep();
-        base.Start();
-        IsSinglePlayer = true;
-        firstQuestButton.onClick.AddListener(() => { SelectQuest(1); });
+        base.Start();        firstQuestButton.onClick.AddListener(() => { SelectQuest(1); });
         if (tutorialNumber == 2)
         {
             thirdQuestButton.interactable = false;
@@ -145,7 +142,7 @@ public class QuestMatchPopup : RankedMatchPopup
         }
     }
 
-    protected override async void StartAIMatchAsync()
+    protected override async void StartMatchAsync()
     {
         try
         {

--- a/Scripts/Menu/Popups/TrainingMatchPopup.cs
+++ b/Scripts/Menu/Popups/TrainingMatchPopup.cs
@@ -1,0 +1,25 @@
+using System;
+using Dawnshard.Menu;
+using MoreMountains.Feedbacks;
+using UnityEngine;
+
+namespace Dawnshard.Menu
+{
+    public class TrainingMatchPopup : MatchPopup
+    {
+        protected override async void StartMatchAsync()
+        {
+            PlayWaitingAnimation();
+            try
+            {
+                await GameController.Instance.StartAIMatch(deckPresenter.Model.Name, false);
+                isSearchingForMatch = true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                ShowError(e.Message);
+            }
+        }
+    }
+}

--- a/Scripts/Menu/States/PlayState.cs
+++ b/Scripts/Menu/States/PlayState.cs
@@ -18,6 +18,7 @@ namespace Dawnshard.Menu
         }
 
         [SerializeField] private RankedMatchPopup rankedMatchPopup;
+        [SerializeField] private TrainingMatchPopup trainingMatchPopup;
         [SerializeField] private QuestMatchPopup questMatchPopup;
         [SerializeField] private GameObject deckParent;
         [SerializeField] private PopupOneButton popupOneButton;
@@ -47,6 +48,7 @@ namespace Dawnshard.Menu
             OnQuestMatchPressed();
             questMatchPopup.Close();
             rankedMatchPopup.Close();
+            trainingMatchPopup.Close();
         }
 
         private void OnReverseMatchPressed()
@@ -75,7 +77,6 @@ namespace Dawnshard.Menu
             }
             DeleteAllViews();
             currentState = PlayStateType.Quest;
-            questMatchPopup.IsSinglePlayer = true;
             ShowDecks();
         }
 
@@ -96,8 +97,7 @@ namespace Dawnshard.Menu
         private void OnTrainingMatchPressed()
         {
             DeleteAllViews();
-            currentState = PlayStateType.Ranked;
-            rankedMatchPopup.IsSinglePlayer = true;
+            currentState = PlayStateType.Friendly;
             ShowDecks();
         }
 
@@ -110,7 +110,6 @@ namespace Dawnshard.Menu
 
         private void DeleteAllViews()
         {
-            rankedMatchPopup.IsSinglePlayer = false;
             rankedMatchPopup.IsReverseMode = false;
             deckPresenters.Clear();
             foreach (Transform child in deckParent.transform)
@@ -119,6 +118,7 @@ namespace Dawnshard.Menu
             }
             questMatchPopup.Close();
             rankedMatchPopup.Close();
+            trainingMatchPopup.Close();
         }
 
         private void SelectDeck(DeckModel deck)
@@ -128,6 +128,11 @@ namespace Dawnshard.Menu
             {
                 rankedMatchPopup.SetDeckView(deck, () => EnableDecksInteraction(true));
                 rankedMatchPopup.Open();
+            }
+            else if (currentState == PlayStateType.Friendly)
+            {
+                trainingMatchPopup.SetDeckView(deck, () => EnableDecksInteraction(true));
+                trainingMatchPopup.Open();
             }
             else if (currentState == PlayStateType.Quest)
             {


### PR DESCRIPTION
## Summary
- add abstract `MatchPopup` base
- create `TrainingMatchPopup` for AI matches
- refactor `RankedMatchPopup` to use new base
- adapt `QuestMatchPopup` to extend `TrainingMatchPopup`
- integrate new popup in `PlayState`

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f144255c8330bf39f17ffbb44cc7